### PR TITLE
1分はやく送信されてそう

### DIFF
--- a/cron/src/lib.rs
+++ b/cron/src/lib.rs
@@ -69,8 +69,8 @@ async fn task<
 ) {
     use indoc::formatdoc;
     let now = Utc::now();
-    let start = now;
-    let end = now + Duration::minutes(1);
+    let start = now - Duration::minutes(1);
+    let end = now;
     let Ok(cards_with_channels) = card_repository
         .get_card_with_channels_by_date(start, end)
         .await


### PR DESCRIPTION
たとえば00:00:00.123にdbをたたくと00:00:01.000に送信予定のカードが含まれてしまっていた